### PR TITLE
Update catalog source config; change working directory

### DIFF
--- a/scripts/setup-cloudwatch-logs.sh
+++ b/scripts/setup-cloudwatch-logs.sh
@@ -24,7 +24,7 @@ sudo yum update -y
 # Install amazon-cloudwatch-agent
 sudo yum install amazon-cloudwatch-agent -y
 
-cat <<EOF > /tmp/scripts/config.json
+cat <<EOF > /opt/ibm/scripts/config.json
 {
         "agent": {
                 "run_as_user": "${BOOTNODE_USER}"
@@ -40,25 +40,25 @@ cat <<EOF > /tmp/scripts/config.json
                                            "retention_in_days": -1
                                    },
                                    {
-                                           "file_path": "/tmp/eksctl.log",
+                                           "file_path": "/opt/ibm/eksctl.log",
                                            "log_group_name": "${MAIN_STACK_NAME}",
                                            "log_stream_name": "eksctl.log",
                                            "retention_in_days": -1
                                    },
                                    {
-                                           "file_path": "/tmp/deployment.properties",
+                                           "file_path": "/opt/ibm/deployment.properties",
                                            "log_group_name": "${MAIN_STACK_NAME}",
                                            "log_stream_name": "deployment.properties",
                                            "retention_in_days": -1
                                    },
                                    {
-                                           "file_path": "/tmp/ibm-liberty-app-deploy.yaml",
+                                           "file_path": "/opt/ibm/ibm-liberty-app-deploy.yaml",
                                            "log_group_name": "${MAIN_STACK_NAME}",
                                            "log_stream_name": "ibm-liberty-app-deploy.yaml",
                                            "retention_in_days": -1
                                    },
                                    {
-                                           "file_path": "/tmp/ibm-liberty-app-deploy-service.yaml",
+                                           "file_path": "/opt/ibm/ibm-liberty-app-deploy-service.yaml",
                                            "log_group_name": "${MAIN_STACK_NAME}",
                                            "log_stream_name": "ibm-liberty-app-deploy-service.yaml",
                                            "retention_in_days": -1
@@ -70,16 +70,16 @@ cat <<EOF > /tmp/scripts/config.json
 }
 EOF
 
-sudo cp /tmp/scripts/config.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
+sudo cp /opt/ibm/scripts/config.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
 
 sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
 
 # Trigger CloudWatch agent to watch files to be sent to CloudWatch logs.
-sudo mv /tmp/eksctl.log /tmp/eksctl.log.tmp
-sudo cat /tmp/eksctl.log.tmp > /tmp/eksctl.log
-sudo cat /tmp/scripts/ibm-liberty-parameters.properties | sort > /tmp/deployment.properties
+sudo mv /opt/ibm/eksctl.log /opt/ibm/eksctl.log.tmp
+sudo cat /opt/ibm/eksctl.log.tmp > /opt/ibm/eksctl.log
+sudo cat /opt/ibm/scripts/ibm-liberty-parameters.properties | sort > /opt/ibm/deployment.properties
 
 # The app-deploy and -service YAML definitions are copied over empty
 # to enable the customer to view and use these templates as-is
-sudo cp /tmp/scripts/templates/ibm-liberty-app-deploy.yaml /tmp
-sudo cp /tmp/scripts/templates/ibm-liberty-app-deploy-service.yaml /tmp
+sudo cp /opt/ibm/scripts/templates/ibm-liberty-app-deploy.yaml /opt/ibm
+sudo cp /opt/ibm/scripts/templates/ibm-liberty-app-deploy-service.yaml /opt/ibm

--- a/scripts/templates/catalog_source.yaml
+++ b/scripts/templates/catalog_source.yaml
@@ -10,6 +10,8 @@ spec:
   publisher: IBM
   sourceType: grpc
   image: icr.io/cpopen/ibm-operator-catalog:latest
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 45m

--- a/templates/ibm-liberty-create-eks.template.yaml
+++ b/templates/ibm-liberty-create-eks.template.yaml
@@ -38,27 +38,27 @@ Resources:
         - |
           #!/bin/bash
           i=0
-          while [ ! -f /tmp/cluster.yaml ]; do 
-            echo "/tmp/cluster.yaml isn't available yet, waiting"
+          while [ ! -f /opt/ibm/cluster.yaml ]; do 
+            echo "/opt/ibm/cluster.yaml isn't available yet, waiting"
             sleep 5
             i=$[$i+1]
             if [ $i -ge 12 ]; then
-              echo "Timed out waiting 60 seconds for /tmp/cluster.yaml to be available"
+              echo "Timed out waiting 60 seconds for /opt/ibm/cluster.yaml to be available"
               break; 
             fi
-            echo "/tmp/cluster.yaml ready:"
-            cat /tmp/cluster.yaml
+            echo "/opt/ibm/cluster.yaml ready:"
+            cat /opt/ibm/cluster.yaml
           done
         - !If
           - IsFargate
           - !Sub |
             #!/bin/bash
-            eksctl create cluster --fargate --name ${EKSClusterName} --region ${AWS::Region} > /tmp/eksctl.log
+            eksctl create cluster --fargate --name ${EKSClusterName} --region ${AWS::Region} > /opt/ibm/eksctl.log
           - |
             #!/bin/bash
-            eksctl create cluster -f /tmp/cluster.yaml > /tmp/eksctl.log
+            eksctl create cluster -f /opt/ibm/cluster.yaml > /opt/ibm/eksctl.log
         workingDirectory:
-        - /tmp
+        - /opt/ibm
       WaitForSuccessTimeoutSeconds: 1200
 
   LambdaExecutionRole:
@@ -157,9 +157,9 @@ Resources:
                     try:
                       response = ssm.send_command(Targets=[{"Key":"instanceids","Values":[instanceID]}],
                               DocumentName="AWS-RunShellScript",
-                              Parameters={"commands":[f"/tmp/scripts/destroy.sh >> /tmp/eksctl.log"],
+                              Parameters={"commands":[f"/opt/ibm/scripts/destroy.sh >> /opt/ibm/eksctl.log"],
                                           "executionTimeout":["1800"],
-                                          "workingDirectory":["/tmp/scripts"]},
+                                          "workingDirectory":["/opt/ibm/scripts"]},
                               Comment="Execute script to delete EKS cluster",
                               TimeoutSeconds=180)
                       break

--- a/templates/ibm-liberty-ec2-bootnode.template.yaml
+++ b/templates/ibm-liberty-ec2-bootnode.template.yaml
@@ -51,8 +51,12 @@ Resources:
           Required:
             - StackPropertiesFile
         StackPropertiesFile:
+          commands:
+            01_create_opt_ibm:
+              command: mkdir -p /opt/ibm
+              test: test ! -d /opt/ibm
           files:
-            /tmp/cluster.yaml:
+            /opt/ibm/cluster.yaml:
               mode: '000755'
               owner: root
               group: root

--- a/templates/ibm-liberty-eks-workload.template.yaml
+++ b/templates/ibm-liberty-eks-workload.template.yaml
@@ -157,7 +157,7 @@ Resources:
           echo "CLOUDWATCH_INSTALL_LOGS=https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#logsV2:log-groups/log-group/${MainStackName}" >> scripts/ibm-liberty-parameters.properties
           echo "EKS_ADMIN_USER_ARNS='${AdditionalEKSAdminArns}'" >> scripts/ibm-liberty-parameters.properties
           echo "EKS_CLUSTER_NAME=${EKSClusterName}" >> scripts/ibm-liberty-parameters.properties
-          echo "INSTALL_LOG_LOCATION=/tmp/install.log" >> scripts/ibm-liberty-parameters.properties
+          echo "INSTALL_LOG_LOCATION=/opt/ibm/install.log" >> scripts/ibm-liberty-parameters.properties
           echo "LAUNCH_TYPE=${LaunchType}" >> scripts/ibm-liberty-parameters.properties
           echo "LICENSE_EDITION='${LicenseEdition}'" >> scripts/ibm-liberty-parameters.properties
           echo "LICENSE_ENTITLEMENT='${LicenseProductEntitlementSource}'" >> scripts/ibm-liberty-parameters.properties
@@ -170,10 +170,10 @@ Resources:
           chown -R ${BootNodeUser} ./templates ./scripts ./install.log
           chgrp -R ${BootNodeUser} ./templates ./scripts ./install.log
 
-          su - ${BootNodeUser} -c '/tmp/scripts/install.sh' | tee install.log
+          su - ${BootNodeUser} -c '/opt/ibm/scripts/install.sh' | tee install.log
 
         workingDirectory:
-        - /tmp
+        - /opt/ibm
       WaitForSuccessTimeoutSeconds: 1200
 
   LambdaExecutionRole:

--- a/templates/ibm-liberty-new-eks-no-app.template.yaml
+++ b/templates/ibm-liberty-new-eks-no-app.template.yaml
@@ -211,7 +211,7 @@ Outputs:
     Value: !GetAtt IBMLibertyBootNodeStack.Outputs.InstanceName
   InstallLogsLocation:
     Description: Install logs location (on boot node)
-    Value: "/tmp/install.log"
+    Value: "/opt/ibm/install.log"
   CloudWatchInstallLogs:
     Description: Installation logs (in CloudWatch)
     Value: !GetAtt IBMLibertyWorkloadStack.Outputs.CloudWatchInstallLogs

--- a/templates/ibm-liberty-new-eks-with-app.template.yaml
+++ b/templates/ibm-liberty-new-eks-with-app.template.yaml
@@ -306,10 +306,10 @@ Outputs:
     Value: !GetAtt IBMLibertyBootNodeStack.Outputs.InstanceName
   InstallLogsLocation:
     Description: Install logs location (on boot node)
-    Value: "/tmp/install.log"
+    Value: "/opt/ibm/install.log"
   LibertyAppCRLocation:
     Description: Location (on boot node) of the deployed Liberty app CR
-    Value: "/tmp/scripts/templates/ibm-liberty-app-deploy.yaml"
+    Value: "/opt/ibm/scripts/templates/ibm-liberty-app-deploy.yaml"
   CloudWatchInstallLogs:
     Description: Installation logs (in CloudWatch)
     Value: !GetAtt IBMLibertyWorkloadStack.Outputs.CloudWatchInstallLogs


### PR DESCRIPTION
*Issue #, if available:* 

closes #35 
closes #36

*Description of changes:*

First, I noticed a problem after installing OLM on the cluster, adding the IBM Operator Catalog, and installing the WebSphere Liberty Operator. The operator never started running and the installation script eventually times out. This was due to a [known issue](https://github.com/operator-framework/operator-lifecycle-manager/issues/2914) in OLM v0.23.0 where any operators installed from the community catalog source (for OperatorHub) would also fail to run. This was patched in v0.23.1 by simply setting `spec.grpcPodConfig.securityContextConfig` to `restricted` on the catalog source. So I applied the same change to the IBM Operator Catalog source, and the problem was fixed - WLO installed and runs successfully after that change.

Second, I switched the "working directory" used as the location for scripts, templates, and log files from `/tmp` to `/opt/ibm` in order to make sure these files don't get deleted when `/tmp` is cleared.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
